### PR TITLE
Add documentation for proposed fileserver timeout flag

### DIFF
--- a/docs/guides-references/command-line/hauler-store.md
+++ b/docs/guides-references/command-line/hauler-store.md
@@ -320,6 +320,7 @@ Flags:
       --directory string   Directory to use for backend.  Defaults to $PWD/store-files (default "store-files")
   -h, --help               help for fileserver
   -p, --port int           Port to listen on. (default 8080)
+  -t, --timeout int        Set the http request timeout duration in seconds for both reads and write. (default 60)
 
 Global Flags:
       --cache string       Location of where to store cache data (defaults to $XDG_CACHE_DIR/hauler)


### PR DESCRIPTION
- Updated "Next" documentation to include a proposed timeout flag.
- Associated dev PR: [247](https://github.com/rancherfederal/hauler/pull/247)
- Example: 
```
➜  hauler store -s testing-timeout serve fileserver --help
Serve the file server

Usage:
  hauler store serve fileserver [flags]

Flags:
      --directory string   Directory to use for backend.  Defaults to $PWD/fileserver (default "fileserver")
  -h, --help               help for fileserver
  -p, --port int           Port to listen on. (default 8080)
  -t, --timeout int        Set the http request timeout duration in seconds for both reads and write. (default 60)

Global Flags:
      --cache string       (deprecated flag and currently not used)
  -l, --log-level string    (default "info")
  -s, --store string       Location to create store at (default "store")
```